### PR TITLE
Remove environment specific terminal output

### DIFF
--- a/blog/00-getting-started.md
+++ b/blog/00-getting-started.md
@@ -38,8 +38,8 @@ We can initialize a LoopBack application in our terminal by typing `lb` or `lb a
 ### What's the name of your application?
 
 ```
-➜  workshop-band-app git:(master) lb
-? What's the name of your application? (workshop-band-app)
+$ lb
+? What's the name of your application? (work-folder-name)
 ```
 
 The first step is to name our application. Let's call it: `band-app`.


### PR DESCRIPTION
I changed the command line indicator to be more in line with the conventional `$` both LoopBack uses and is used lower in the "Next Steps" part.

I also renamed the starting folder to be something generic.